### PR TITLE
Guard autocast on unsupported devices

### DIFF
--- a/beat_this/model/beat_tracker.py
+++ b/beat_this/model/beat_tracker.py
@@ -318,10 +318,11 @@ class SumHead(nn.Module):
         beat, downbeat = rearrange(beat_downbeat, "b t c -> c b t", c=2)
         # aggregate beats and downbeats prediction
         # autocast to float16 disabled to avoid numerical issues causing NaNs
-        autocast_ctx = contextlib.nullcontext()
-        if beat.device.type in ("cuda", "cpu"):
-            autocast_ctx = torch.autocast(beat.device.type, enabled=False)
-        with autocast_ctx:
+        if torch.amp.is_autocast_available(beat.device.type):
+            disable_autocast = torch.autocast(beat.device.type, enabled=False)
+        else:
+            disable_autocast = contextlib.nullcontext()
+        with disable_autocast:
             beat = beat.float() + downbeat.float()
         return {"beat": beat, "downbeat": downbeat}
 

--- a/beat_this/model/beat_tracker.py
+++ b/beat_this/model/beat_tracker.py
@@ -3,6 +3,7 @@ Model definitions for the Beat This! beat tracker.
 """
 
 from collections import OrderedDict
+import contextlib
 
 import torch
 from einops import rearrange
@@ -317,7 +318,10 @@ class SumHead(nn.Module):
         beat, downbeat = rearrange(beat_downbeat, "b t c -> c b t", c=2)
         # aggregate beats and downbeats prediction
         # autocast to float16 disabled to avoid numerical issues causing NaNs
-        with torch.autocast(beat.device.type, enabled=False):
+        autocast_ctx = contextlib.nullcontext()
+        if beat.device.type in ("cuda", "cpu"):
+            autocast_ctx = torch.autocast(beat.device.type, enabled=False)
+        with autocast_ctx:
             beat = beat.float() + downbeat.float()
         return {"beat": beat, "downbeat": downbeat}
 


### PR DESCRIPTION
Disable autocast on MPS (and other unsupported backends) to avoid runtime errors while keeping existing behavior on CPU/CUDA.

Reproduction
```python
import torch

x = torch.randn(2, 3, device="mps")

# This raises: RuntimeError: User specified an unsupported autocast device_type 'mps'
with torch.autocast("mps", enabled=False):
    y = x.float()
```
